### PR TITLE
package/protectli-fw/Makefile: fix broken makefile

### DIFF
--- a/package/protectli-fw/Makefile
+++ b/package/protectli-fw/Makefile
@@ -8,28 +8,32 @@ PKG_NAME:=protectli-fw
 PKG_VERSION:=0.3.1
 PKG_RELEASE:=1
 
-PKG_SOURCE_URL:=https://kb.protectli.com/wp-content/uploads/sites/9/2023/06
 PKG_SOURCE:=wifi-fix-standalone-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://kb.protectli.com/wp-content/uploads/sites/9/2023/06
 PKG_HASH:=dad3dcb0fd08a546d45e4420c99b7d00496274bd7824a66dd3e5b65b2bba46ba
+
+PKG_SOURCE_SUBDIR:=wifi-fix-standalone
+PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_SOURCE_SUBDIR)
 
 include $(INCLUDE_DIR)/package.mk
 
-define Package/protectli-fw
+define Package/$(PKG_NAME)
   SECTION:=firmware
   CATEGORY:=Firmware
-  TITLE:=Protectli QCA6174 Wi-Fi board/firmware blobs
+  TITLE:=Protectli QCA6174 Wi-Fi board / firmware blobs
 endef
 
 define Build/Compile
-	# nothing to build - just copy blobs
 endef
 
-define Package/protectli-fw/install
+define Package/$(PKG_NAME)/install
 	$(INSTALL_DIR) $(1)/lib/firmware/ath10k/QCA6174/hw3.0
-	$(INSTALL_DATA) $(PKG_BUILD_DIR)/wifi-fix-standalone/vendor/board-2.bin    \
+	$(INSTALL_DATA) \
+		$(PKG_BUILD_DIR)/vendor/board-2.bin \
 		$(1)/lib/firmware/ath10k/QCA6174/hw3.0/
-	$(INSTALL_DATA) $(PKG_BUILD_DIR)/wifi-fix-standalone/vendor/firmware-6.bin \
+	$(INSTALL_DATA) \
+		$(PKG_BUILD_DIR)/vendor/firmware-6.bin \
 		$(1)/lib/firmware/ath10k/QCA6174/hw3.0/
 endef
 
-$(eval $(call BuildPackage,protectli-fw))
+$(eval $(call BuildPackage,$(PKG_NAME)))


### PR DESCRIPTION
fix non-working recipe (when building from scratch it used to fail, now it doesn't)